### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spiralwake.yml
+++ b/.github/workflows/spiralwake.yml
@@ -1,5 +1,8 @@
 name: SpiralWake CI/CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -219,6 +222,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -269,6 +274,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/SpiralWake/security/code-scanning/5](https://github.com/CreoDAMO/SpiralWake/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for all jobs. Additionally, we will add job-specific `permissions` blocks for jobs that require elevated permissions, such as `deploy` and `release`. This ensures that each job has only the permissions it needs to function correctly.

1. Add a `permissions` block at the top of the workflow to set the default permissions to `contents: read`.
2. Add job-specific `permissions` blocks for the `deploy` and `release` jobs to grant additional permissions (`contents: write` for `release` and `contents: read` for `deploy`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
